### PR TITLE
Fix button being too large on certain websites

### DIFF
--- a/src/css/light.css
+++ b/src/css/light.css
@@ -617,7 +617,7 @@ To view a copy of this license, visit http://creativecommons.org/licenses/GPL/2.
 @keyframes animStar{from{transform:translateY(0px)}to{transform:translateY(-2000px)}}
 /* Night Theme */
 #stefanvdnighttheme.stefanvdswitchhidden{display:none!important}
-#stefanvdnighttheme{padding:0!important;margin:0!important;z-index:990!important;-webkit-user-select:none!important;-moz-user-select:none!important;user-select:none!important;background:#fff!important;border:1px solid #EBEBEB!important;box-shadow:#fff 0 0 7px;border-radius:4px!important;cursor:pointer!important;height:35px!important;margin:0!important;overflow:hidden!important;position:fixed!important;width:70px!important}
+#stefanvdnighttheme{padding:0!important;margin:0!important;z-index:990!important;-webkit-user-select:none!important;-moz-user-select:none!important;user-select:none!important;background:#fff!important;border:1px solid #EBEBEB!important;box-shadow:#fff 0 0 7px;border-radius:4px!important;cursor:pointer!important;height:35px!important;margin:0!important;overflow:hidden!important;position:fixed!important;width:70px!important;min-height:auto!important;min-width:auto!important;min-block-size:auto!important;}
 #stefanvdnighttheme input{display:none!important}
 #stefanvdnighttheme input:checked + #stefanvdnightthemeslider{left:0!important}
 #stefanvdnighttheme #stefanvdnightthemeslider{left:-35px!important;position:absolute!important;top:0!important;-webkit-transition:left .25s ease-out;-moz-transition:left .25s ease-out;-o-transition:left .25s ease-out;-ms-transition:left .25s ease-out;transition:left .25s ease-out}


### PR DESCRIPTION
Websites that changed min-height, min-width, or min-block-size for all labels would also affect the theme button previously. Here's an example site where you can see this issue: https://bitblitobvimormon.github.io/searchable-standard-works/search

This fix should remove the issue.
